### PR TITLE
fixed bad curl cmd in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,5 +104,6 @@ In the demo configuration, all mail is sent to a null sink pod that immediately 
 
 ```
 curl -H "Content-Type: application/json" -u user1:dfad6143b4520f8526e4f9a0b25ab42b \
-http://localhost:8000/api/inject/v1 \ -d @sample_http_inject_payload.json
+http://localhost:8000/api/inject/v1 \
+-d @sample_http_inject_payload.json
 ```


### PR DESCRIPTION
In Unix shell you can't have space after a \

❌ Broken version:

```
curl -H "Content-Type: application/json" -u user1:dfad6143b4520f8526e4f9a0b25ab42b \
  http://localhost:8000/api/inject/v1 \ -d @sample_http_inject_payload.json
```

    Problem:
    There's a space between the backslash and the -d:

    \ -d

That breaks the line continuation. The shell thinks -d is part of the URL or a separate command, leading to:

```
curl: (3) URL using bad/illegal format or missing URL
curl: (6) Could not resolve host: sample_http_inject_payload.json
```

✅ Correct version:

```
curl -H "Content-Type: application/json" -u user1:dfad6143b4520f8526e4f9a0b25ab42b \
http://localhost:8000/api/inject/v1 \
-d @sample_http_inject_payload.json
```
or without end of line
```
curl -H "Content-Type: application/json" -u user1:dfad6143b4520f8526e4f9a0b25ab42b \
http://localhost:8000/api/inject/v1 -d @sample_http_inject_payload.json
```

with end of line visible as $
```
curl -H "Content-Type: application/json" -u user1:dfad6143b4520f8526e4f9a0b25ab42b \$
http://localhost:8000/api/inject/v1 \$
-d @sample_http_inject_payload.json$
```

Notice:
    The backslash \ is used at the end of the line without any trailing characters — not even a space.

So the fix is: remove the space between the backslash and -d — the backslash must be the last character on the line.
